### PR TITLE
Sharepoint federated

### DIFF
--- a/lib/objects/listItems.js
+++ b/lib/objects/listItems.js
@@ -23,6 +23,22 @@ module.exports = function(client) {
           return cb(null, items);
         });
       },
+      listByTitle: function(listTitle, cb) {
+        var host = client.BASE_LIST_URL + "GetByTitle('" + listTitle + "')" + "/Items";
+
+        //FieldValuesAsText is not supported here by Sharepoint, Append filterFields
+        // and / or selectFields  and / or expandFields to host
+        host = urlBuilder.augmentURL(host, false, client.filterFields, client.selectFields, client.expandFields,client.orOperator);
+
+        //console.log('list Items URL ' + host);
+        return doRequest(host, function(err, items) {
+          if (err) {
+            return cb(err);
+          }
+          //items = conveniences('ListItems', items, listId);
+          return cb(null, items);
+        });
+      },      
       currentuser: function(filter, cb) {
       //console.log("i am in ");
       //console.log("Client Object in litsItems.js -->",client);

--- a/lib/objects/listItems.js
+++ b/lib/objects/listItems.js
@@ -24,7 +24,7 @@ module.exports = function(client) {
         });
       },
       listByTitle: function(listTitle, cb) {
-        var host = client.BASE_LIST_URL + "GetByTitle('" + listTitle + "')" + "/Items";
+        var host = client.BASE_LIST_URL + "/GetByTitle('" + listTitle + "')" + "/Items";
 
         //FieldValuesAsText is not supported here by Sharepoint, Append filterFields
         // and / or selectFields  and / or expandFields to host

--- a/lib/objects/listItems.js
+++ b/lib/objects/listItems.js
@@ -30,7 +30,7 @@ module.exports = function(client) {
         // and / or selectFields  and / or expandFields to host
         host = urlBuilder.augmentURL(host, false, client.filterFields, client.selectFields, client.expandFields,client.orOperator);
 
-        //console.log('list Items URL ' + host);
+        console.log('list Items URL ' + host);
         return doRequest(host, function(err, items) {
           if (err) {
             return cb(err);


### PR DESCRIPTION
Added one new method listByTitle. This is for using sharepoints 'GetByTitle' feature, thus, we can avoid hardcoding list ids in our code.
